### PR TITLE
Fix absolute path transformations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-ng-template-url-absolutify",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "ViES <vies@list.ru>",
   "license": "MIT",
   "description": "Transform AngularJS templateUrl relative paths to absolute URLs.",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,14 @@
 import {resolve, dirname} from 'path';
 
+const isValidUrl = string => {
+    try {
+        new URL(string);
+        return true;
+    } catch (_) {
+        return false;
+    }
+};
+
 export default function ({types: t}) {
     return {
         visitor: {
@@ -9,15 +18,15 @@ export default function ({types: t}) {
                     if (t.isStringLiteral(path.node.value)) {
 
                         const {baseDir, baseUrl} = state.opts;
-
                         const dir = dirname(state.file.opts.filename);
                         const templateUrl = path.node.value.value;
 
-                        const absolutePath = resolve(dir, templateUrl);
+                        if (!isValidUrl(templateUrl)) {
+                            const absolutePath = resolve(dir, templateUrl);
+                            const url = baseUrl + absolutePath.replace(resolve(baseDir), '');
 
-                        const url = baseUrl + absolutePath.replace(resolve(baseDir), '');
-
-                        path.node.value = t.stringLiteral(url);
+                            path.node.value = t.stringLiteral(url);
+                        }
                     }
             }
         }


### PR DESCRIPTION
If templateUrl is valid URL - don't transform it.